### PR TITLE
Globus persistence state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,8 @@ RUN mkdir -p /var/lib/globus/simple_ca
 RUN apt-get -y install globus-connect-server
 #RUN echo "HI! $GLOBUS_USER"
 
+RUN mkdir -p /globus_state
+RUN mkdir -p /data
+
 ENV TERM xterm
 ADD ./entry_point.sh .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,7 @@ services:
       - HOSTNAME
       - GLOBUS_ACTIVATE_USER
       - GLOBUS_ACTIVATE_PASSWORD
+      - GLOBUS_CREATE_STATE_COPY
+    volumes:
+      - ./globus_state:/globus_state
+      - ./data:/data

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -12,9 +12,25 @@
 #  the server runs.
 # GLOBUS_ACTIVATE_PASSWORD password of the GLOBUS_ACTIVATE_USER.
 
+globus_state_file_name="globus_state.tar.gz"
+globus_state_dir="/globus_state"
+globus_state_file="${globus_state_dir}/${globus_state_file_name}"
+
 echo "Creating activation user"
 useradd -ms /bin/bash "${GLOBUS_ACTIVATE_USER}"
 echo ""${GLOBUS_ACTIVATE_USER}":"${GLOBUS_ACTIVATE_PASSWORD}"" | chpasswd
 echo "Configuring globus"
+if [ "$GLOBUS_CREATE_STATE_COPY" != 1 ] &&  [ -f "$globus_state_file" ]
+then
+  echo "Restoring Globus state"
+  tar -xvzf "${globus_state_file}"
+fi
 globus-connect-server-setup
+if [ "$GLOBUS_CREATE_STATE_COPY" = 1 ]
+then
+  echo "Making copy of globus state, copying into ${globus_state_file}"
+  tar -cvzf "${globus_state_file}" /var/lib/globus  \
+/var/lib/globus-connect-server /var/lib/myproxy /var/lib/myproxy-oauth
+fi
+echo "All done... Server running"
 sleep infinity

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -18,7 +18,7 @@ globus_state_file="${globus_state_dir}/${globus_state_file_name}"
 
 clean_close() {
   echo "Gracefully stopping the server"
-  if [ "$GLOBUS_CREATE_STATE_COPY" = 1 ]
+  if [ "$GLOBUS_PERSISTENT" = 1 ]
   then
     echo "Making copy of globus state, copying into ${globus_state_file}"
     tar -cvzf "${globus_state_file}" /var/lib/globus  \
@@ -35,11 +35,12 @@ echo "Creating activation user"
 useradd -ms /bin/bash "${GLOBUS_ACTIVATE_USER}"
 echo ""${GLOBUS_ACTIVATE_USER}":"${GLOBUS_ACTIVATE_PASSWORD}"" | chpasswd
 echo "Configuring globus"
-if [ -f "$globus_state_file" ]
+if [ -f "$globus_state_file" ] and [ "$GLOBUS_PERSISTENT" = 1 ]
 then
   echo "Restoring Globus state"
   tar -xvzf "${globus_state_file}"
 fi
 globus-connect-server-setup
 echo "All done... Server running"
-sleep infinity
+sleep infinity &
+wait


### PR DESCRIPTION
The PR adds persistence to the state of the Globus Connect Server container if desired. 

If env. var  GLOBUS_PERSISTENT is set to 1:
- Sever state will be loaded from a file in /globus_state if file exists.
- Upon graceful stop (SIGINT, SIGTERM), server state is stored in /globus_state

Notes:
- /globus_state must be mounted to a host space to have persistence.
- docker-compose up/down ensure that /globus_state is mounted and that the container is closed gracefully.
