### PR TITLE
Better NAT support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update
 RUN apt-get -y install ntp
 RUN mkdir -p /var/lib/globus/simple_ca
 RUN apt-get -y install globus-connect-server
-#RUN echo "HI! $GLOBUS_USER"
 
 RUN mkdir -p /globus_state
 RUN mkdir -p /data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - GLOBUS_ACTIVATE_USER
       - GLOBUS_ACTIVATE_PASSWORD
       - GLOBUS_PERSISTENT
+      - PUBLIC_ID
     volumes:
       - ./globus_state:/globus_state
       - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - GLOBUS_ACTIVATE_USER
       - GLOBUS_ACTIVATE_PASSWORD
       - GLOBUS_PERSISTENT
-      - PUBLIC_ID
+      - PUBLIC_IP
     volumes:
       - ./globus_state:/globus_state
       - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   globus:
     build:
       context: .
-    hostname: "${SHORT_HOSTNAME}"
-    domainname: "${DOMAIN_NAME}"
+    #hostname: "${SHORT_HOSTNAME}"
+    #domainname: "${DOMAIN_NAME}"
     ports:
       - "2811:2811"
       - "50000-50100:50000-50100"
@@ -16,7 +16,7 @@ services:
       - GLOBUS_USER
       - GLOBUS_PASSWORD
       - SHORT_HOSTNAME
-      - HOSTNAME
+      - PUBLIC_HOSTNAME
       - GLOBUS_ACTIVATE_USER
       - GLOBUS_ACTIVATE_PASSWORD
       - GLOBUS_PERSISTENT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     #domainname: "${DOMAIN_NAME}"
     ports:
       - "2811:2811"
-      - "50000-50100:50000-50100"
+      - "50000-51000:50000-51000"
       - "7512:7512"
       - "443:443"
     command: ["./entry_point.sh"]
@@ -20,7 +20,6 @@ services:
       - GLOBUS_ACTIVATE_USER
       - GLOBUS_ACTIVATE_PASSWORD
       - GLOBUS_PERSISTENT
-      - PUBLIC_IP
     volumes:
       - ./globus_state:/globus_state
       - ./data:/data

--- a/globus-connect-server.conf
+++ b/globus-connect-server.conf
@@ -231,7 +231,7 @@ RestrictPaths =
 ; If not set, then no myproxy server will be configured. The special value
 ; %(HOSTNAME)s will substitute an ec2 instance's public hostname, falling back
 ; to the machine's nodename
-Server = %(PUBLICHOSTNAME)s
+Server = %(PUBLIC_HOSTNAME)s
 
 ; If this is set to True, then assume the Server name is the current machine
 ; and configure a MyProxy server on this machine, even if it the Server doesn't

--- a/globus-connect-server.conf
+++ b/globus-connect-server.conf
@@ -115,7 +115,8 @@ IdentityMethod = MyProxy
 ; The host name (and optional port) to contact this GridFTP Server, in the form
 ; host[:port]. If not set, no gridftp server will be configured. The default
 ; pulls the server name from EC2 metadata if present, falling back to the local hostname and uses the default port 2811.
-Server = %(HOSTNAME)s
+Server = %(PUBLIC_HOSTNAME)s
+DataInterface = %(PUBLIC_IP)s
 
 ; If this is set to True, then assume the Server name is the current machine
 ; and configure a GridFTP server on this machine, even if it the Server doesn't
@@ -230,7 +231,7 @@ RestrictPaths =
 ; If not set, then no myproxy server will be configured. The special value
 ; %(HOSTNAME)s will substitute an ec2 instance's public hostname, falling back
 ; to the machine's nodename
-Server = %(HOSTNAME)s
+Server = %(PUBLICHOSTNAME)s
 
 ; If this is set to True, then assume the Server name is the current machine
 ; and configure a MyProxy server on this machine, even if it the Server doesn't

--- a/globus-connect-server.conf
+++ b/globus-connect-server.conf
@@ -116,7 +116,6 @@ IdentityMethod = MyProxy
 ; host[:port]. If not set, no gridftp server will be configured. The default
 ; pulls the server name from EC2 metadata if present, falling back to the local hostname and uses the default port 2811.
 Server = %(PUBLIC_HOSTNAME)s
-DataInterface = %(PUBLIC_IP)s
 
 ; If this is set to True, then assume the Server name is the current machine
 ; and configure a GridFTP server on this machine, even if it the Server doesn't


### PR DESCRIPTION
GCS Configuration file and env vars modified for NAT enviroments (e.g., docker).

PUBLIC_HOSTNAME must be set to the name of the host machine (or public IP from where
traffic is forwarded).